### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/NotSoSimpleConstruction/NotSoSimpleConstruction.version
+++ b/GameData/NotSoSimpleConstruction/NotSoSimpleConstruction.version
@@ -1,6 +1,6 @@
 {
     "NAME"     : "Not So SimpleConstruction",
-    "URL"      : "https://raw.githubusercontent.com/zer0Kerbal/SimpleConstruction/master/GameData/NotSoSimpleConstruction/NotSoSimpleConstruction.version",
+    "URL"      : "https://github.com/zer0Kerbal/NotSoSimpleConstruction/raw/master/NotSoSimpleConstruction.version",
     "DOWNLOAD" : "https://github.com/zer0Kerbal/NotSoSimpleConstruction/releases/latest",
     "GITHUB" :
     {

--- a/NotSoSimpleConstruction.version
+++ b/NotSoSimpleConstruction.version
@@ -1,6 +1,6 @@
 {
     "NAME"     : "Not So SimpleConstruction",
-    "URL"      : "https://raw.githubusercontent.com/zer0Kerbal/SimpleConstruction/master/GameData/NotSoSimpleConstruction/NotSoSimpleConstruction.version",
+    "URL"      : "https://github.com/zer0Kerbal/NotSoSimpleConstruction/raw/master/NotSoSimpleConstruction.version",
     "DOWNLOAD" : "https://github.com/zer0Kerbal/NotSoSimpleConstruction/releases/latest",
     "GITHUB" :
     {


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

@zer0Kerbal is probably getting tired of getting tagged, but GitHub gives me few other options if notifications are to be sent. Apologies!