### PR TITLE
Optional MM patch to add SurvesStation module to all manned command parts

### DIFF
--- a/GameData/NotSoSimpleConstruction/Patches/SurveyStationOptional.txt
+++ b/GameData/NotSoSimpleConstruction/Patches/SurveyStationOptional.txt
@@ -1,4 +1,4 @@
-// This will add the survey station capabality to all manned command parts
+// This will add the survey station capability to all manned command parts
 // Change the file extension to .cfg to activate it
 
 @PART[*]:HAS[MODULE[ModuleCommand],MODULE[!ELSurveyStation],#CrewCapacity[>0]]:NEEDS[SimpleConstruction]:FOR[NotSoSimpleConstruction]

--- a/GameData/NotSoSimpleConstruction/Patches/SurveyStationOptional.txt
+++ b/GameData/NotSoSimpleConstruction/Patches/SurveyStationOptional.txt
@@ -1,0 +1,12 @@
+// This will add the survey station capabality to all manned command parts
+// Change the file extension to .cfg to activate it
+
+@PART[*]:HAS[MODULE[ModuleCommand],MODULE[!ELSurveyStation],#CrewCapacity[>0]]:NEEDS[SimpleConstruction]:FOR[NotSoSimpleConstruction]
+{
+	MODULE
+	{
+		name = ELSurveyStation
+	}
+}
+
+// @LEGIONBOSS


### PR DESCRIPTION
I've seen that you kindly referred to me in SurveyStation.cfg, but my original intention was to add the survey station module to all manned command parts.
So, this optional file would do just that. It's a txt file, so MM won't pick it up right away, only if the user changes the extension to .cfg.
I can also make a pull request on README.md by including this information somewhere if you wish.
You may add any additional information (like versioning or whatever) to this file as you see fit.